### PR TITLE
Fixed addSubscriber when adding new events to the existing list

### DIFF
--- a/prism-event-bus.html
+++ b/prism-event-bus.html
@@ -173,7 +173,7 @@
             let subscriber = this.subscribers.find(item => item.target === element);
             if (subscriber) {
                 let union = this._union(subscriber.types, types);
-                if (union.length > subscriber.types) {
+                if (union.length > subscriber.types.length) {
                     // Append new event type if types is added
                     subscriber.types = union;
                     console.debug(`[${PrismEventBus.is}] event ${types} of ${element.tagName} is registered`);


### PR DESCRIPTION
`PrismEventBus.register(this, [first-event']);
PrismEventBus.register(this, ['second-event']);`
Notice the second event isn't getting registered. This fixes the issue. 

Great component!!! Love it!
The `postDelayed` is pure genius. 